### PR TITLE
Repeated star movement should move to the next word

### DIFF
--- a/plugin/slash.vim
+++ b/plugin/slash.vim
@@ -42,7 +42,7 @@ endfunction
 function! s:trailer()
   augroup slash
     autocmd!
-    autocmd CursorMoved,CursorMovedI * set nohlsearch | unlet b:repeated_move | autocmd! slash
+    autocmd CursorMoved,CursorMovedI * set nohlsearch | unlet! b:repeated_move | autocmd! slash
   augroup END
 
   let seq = foldclosed('.') != -1 ? 'zo' : ''

--- a/plugin/slash.vim
+++ b/plugin/slash.vim
@@ -30,19 +30,19 @@ function! s:wrap(seq)
 endfunction
 
 function! s:immobile(seq)
-  if exists('b:repeated_move')
+  if exists('b:slash_repeated_move')
     return a:seq
   endif
 
   let s:winline = winline()
-  let b:repeated_move = 1
+  let b:slash_repeated_move = 1
   return a:seq."\<plug>(slash-prev)"
 endfunction
 
 function! s:trailer()
   augroup slash
     autocmd!
-    autocmd CursorMoved,CursorMovedI * set nohlsearch | unlet! b:repeated_move | autocmd! slash
+    autocmd CursorMoved,CursorMovedI * set nohlsearch | unlet! b:slash_repeated_move | autocmd! slash
   augroup END
 
   let seq = foldclosed('.') != -1 ? 'zo' : ''

--- a/plugin/slash.vim
+++ b/plugin/slash.vim
@@ -30,14 +30,19 @@ function! s:wrap(seq)
 endfunction
 
 function! s:immobile(seq)
+  if exists('b:repeated_move')
+    return a:seq
+  endif
+
   let s:winline = winline()
+  let b:repeated_move = 1
   return a:seq."\<plug>(slash-prev)"
 endfunction
 
 function! s:trailer()
   augroup slash
     autocmd!
-    autocmd CursorMoved,CursorMovedI * set nohlsearch | autocmd! slash
+    autocmd CursorMoved,CursorMovedI * set nohlsearch | unlet b:repeated_move | autocmd! slash
   augroup END
 
   let seq = foldclosed('.') != -1 ? 'zo' : ''


### PR DESCRIPTION
This pull request:

- Makes the first start keypress immobile
- Makes the second star behave just like a regular star press, moving to the next word.

Even though this changes a core intent of the plugin, which is to change how the star key works, it provides a sane default for people used to the old star behavior.

Let me know what you think.